### PR TITLE
[Web] Theme bug fix

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,8 +4,6 @@ import Link from 'next/link';
 
 import { Sidebar } from '@repo/react-common/sidebar';
 
-import { dehydrate, QueryClient } from '@tanstack/react-query';
-
 import { DesktopNav } from '@/components/Navigation/DesktopNav';
 import { MobileHeader } from '@/components/Navigation/MobileHeader';
 import { MobileNav } from '@/components/Navigation/MobileNav';
@@ -17,7 +15,6 @@ import { ToastNotifications } from '@/components/ToastNotifications';
 import { getPreferences } from '@/features/settings/api';
 import { PreferencesInitializer } from '@/features/settings/components/PreferencesInitializer';
 import { ThemeSynchronizer } from '@/features/settings/components/ThemeSynchronizer';
-import { Preferences } from '@/features/settings/types';
 import { getSession } from '@/lib/session';
 
 import './globals.css';
@@ -40,20 +37,13 @@ export default async function RootLayout({
   const session = await getSession();
   const isLoggedIn = session.isLoggedIn ?? false;
 
-  const queryClient = new QueryClient();
-  if (isLoggedIn) {
-    await queryClient.prefetchQuery({
-      queryKey: ['preferences'],
-      queryFn: getPreferences,
-    });
-  }
-  const dehydratedState = dehydrate(queryClient);
-  const theme = queryClient.getQueryData<Preferences>(['preferences'])?.theme;
+  const preferences = isLoggedIn ? await getPreferences().catch(() => null) : null;
+  const theme = preferences?.theme;
 
   return (
     <html lang="en" className={[inter.variable, theme].filter(Boolean).join(' ')}>
       <body>
-        <Providers dehydratedState={dehydratedState}>
+        <Providers>
           <div className="flex h-screen flex-col lg:flex-row">
             <div className="hidden w-1/4 min-w-80 lg:block">
               <Sidebar linkAs={Link}>

--- a/apps/web/src/components/providers.tsx
+++ b/apps/web/src/components/providers.tsx
@@ -3,9 +3,7 @@
 import toast from 'react-hot-toast';
 
 import {
-  DehydratedState,
   environmentManager,
-  HydrationBoundary,
   MutationCache,
   QueryCache,
   QueryClient,
@@ -57,20 +55,12 @@ function getQueryClient() {
 // Providers
 // --------------------------------
 
-export function Providers({
-  children,
-  dehydratedState,
-}: {
-  children: React.ReactNode;
-  dehydratedState?: DehydratedState;
-}) {
+export function Providers({ children }: { children: React.ReactNode }) {
   const queryClient = getQueryClient();
 
   return (
     <QueryClientProvider client={queryClient}>
-      <HydrationBoundary state={dehydratedState}>
-        <SidebarProvider>{children}</SidebarProvider>
-      </HydrationBoundary>
+      <SidebarProvider>{children}</SidebarProvider>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   );

--- a/apps/web/src/features/settings/components/ThemeSynchronizer.tsx
+++ b/apps/web/src/features/settings/components/ThemeSynchronizer.tsx
@@ -12,22 +12,49 @@ export function ThemeSynchronizer() {
     if (isLoading || isError) return;
 
     const html = document.documentElement;
-    html.classList.remove('light', 'dark');
+
+    function applyTheme(e?: MediaQueryList | MediaQueryListEvent) {
+      html.classList.remove('light', 'dark');
+      if (theme) {
+        html.classList.add(theme);
+      } else {
+        const source = e ?? window.matchMedia('(prefers-color-scheme: dark)');
+        html.classList.add(source.matches ? 'dark' : 'light');
+      }
+    }
+
+    applyTheme();
+
+    // Guard against RSC reconciliation overwriting the theme class between React
+    // commits and the next effect run. The observer corrects the class immediately
+    // (as a microtask, before paint) whenever an external change undoes our work.
+    let guarded = false;
+    const observer = new MutationObserver(() => {
+      if (guarded) return;
+      const prefersDark = !theme && window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const expected = theme ?? (prefersDark ? 'dark' : 'light');
+      if (!html.classList.contains(expected)) {
+        guarded = true;
+        applyTheme();
+        queueMicrotask(() => {
+          guarded = false;
+        });
+      }
+    });
+    observer.observe(html, { attributes: true, attributeFilter: ['class'] });
 
     if (theme) {
-      html.classList.add(theme);
-      return;
+      return () => observer.disconnect();
     }
 
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-    const applySystemTheme = (e: MediaQueryList | MediaQueryListEvent) => {
-      html.classList.remove('light', 'dark');
-      html.classList.add(e.matches ? 'dark' : 'light');
-    };
+    const onSystemChange = (e: MediaQueryListEvent) => applyTheme(e);
+    mediaQuery.addEventListener('change', onSystemChange);
 
-    applySystemTheme(mediaQuery);
-    mediaQuery.addEventListener('change', applySystemTheme);
-    return () => mediaQuery.removeEventListener('change', applySystemTheme);
+    return () => {
+      observer.disconnect();
+      mediaQuery.removeEventListener('change', onSystemChange);
+    };
   }, [theme, isLoading, isError]);
 
   return null;

--- a/apps/web/src/lib/clients/product-client.ts
+++ b/apps/web/src/lib/clients/product-client.ts
@@ -23,7 +23,7 @@ export async function getProductClient() {
 
   const client = createClient<paths>({
     baseUrl: productServiceUrl,
-    fetch: (input: Request) => fetch(new Request(input, { cache: 'no-store' })),
+    fetch: (input: Request) => fetch(input, { cache: 'no-store' }),
   });
   client.use({
     async onRequest({ request }) {

--- a/apps/web/src/lib/clients/user-data-client.ts
+++ b/apps/web/src/lib/clients/user-data-client.ts
@@ -23,7 +23,7 @@ export async function getUserDataClient() {
 
   const client = createClient<paths>({
     baseUrl: userDataServiceUrl,
-    fetch: (input: Request) => fetch(new Request(input, { cache: 'no-store' })),
+    fetch: (input: Request) => fetch(input, { cache: 'no-store' }),
   });
   client.use({
     async onRequest({ request }) {


### PR DESCRIPTION
Theme repaint bug persists. Next HMR somehow arrives with stale data which overwrites the user's set theme.
Previous fix not sufficient,no cache was present since NextJS does opt in caching anyway (still no idea where the erroneous stale theme came from though).

"dehydratedState overwrote the client's live React Query cache. The server fetches preferences on every RSC render (for the SSR <html> theme class). Whatever it returns gets dehydrated and sent to the    
  client with dataUpdatedAt = now. HydrationBoundary sees a newer timestamp than the client's cached value and overwrites it — even with stale data."

Fix: we will not send the potentially stale preferences data to the client anymore. Just fetch it in layout and apply to the <html> tag. The client can fetch and cache preferences itself.
Added observer in ThemeSynchronizer to prevent erroneous theme settings from being applied