### PR TITLE
[Web] Fixed RQ error handling

### DIFF
--- a/apps/web/src/components/Providers.tsx
+++ b/apps/web/src/components/Providers.tsx
@@ -14,6 +14,7 @@ import {
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 import { SESSION_EXPIRED_MESSAGE } from '@/lib/constants';
+import { HttpError } from '@/lib/errors';
 import { extractErrorMessage } from '@/utils/extractApiErrorDetails';
 
 import { SidebarProvider } from './Sidebar';
@@ -30,10 +31,28 @@ function onQueryError(error: Error) {
   toast.error(extractErrorMessage(error));
 }
 
+function isFieldLevelError(error: Error): boolean {
+  return (
+    error instanceof HttpError &&
+    typeof error.details === 'object' &&
+    error.details !== null &&
+    typeof (error.details as { properties?: unknown }).properties === 'object'
+  );
+}
+
+function onMutationError(error: Error) {
+  if (error.message === SESSION_EXPIRED_MESSAGE) {
+    window.location.replace('/login?reason=session_expired');
+    return;
+  }
+  if (isFieldLevelError(error)) return;
+  toast.error(extractErrorMessage(error));
+}
+
 function makeQueryClient() {
   return new QueryClient({
     queryCache: new QueryCache({ onError: onQueryError }),
-    mutationCache: new MutationCache({ onError: onQueryError }),
+    mutationCache: new MutationCache({ onError: onMutationError }),
     defaultOptions: {
       queries: {
         staleTime: 5 * 60 * 1000,

--- a/apps/web/src/features/category/components/CategoryDeleteModal.tsx
+++ b/apps/web/src/features/category/components/CategoryDeleteModal.tsx
@@ -9,7 +9,6 @@ import { Button, SubmitButton } from '@repo/react-common/button';
 import { Spinner } from '@repo/react-common/spinner';
 
 import { Modal } from '@/components/Modal';
-import { extractErrorMessage } from '@/utils/extractApiErrorDetails';
 
 import { useCategoryDeleteImpact, useDeleteCategory } from '../queries';
 
@@ -33,9 +32,6 @@ export default function CategoryDeleteModal(props: CategoryDeleteModalProps) {
         onClose();
         toast.success('Category deleted successfully');
       },
-      onError: (error) => {
-        toast.error(`Error: ${extractErrorMessage(error)}`);
-      },
     });
   };
 
@@ -52,9 +48,20 @@ export default function CategoryDeleteModal(props: CategoryDeleteModalProps) {
     );
   } else if (isError) {
     dialogContent = (
-      <p className="text-danger">
-        Could not load impact data. You may still proceed with deletion.
-      </p>
+      <>
+        <p className="text-danger">
+          Could not load impact data. Any item which has this category assigned will be
+          uncategorized. You can check manually on the items page or try again later.
+        </p>
+        <Link
+          href={`/items?category=${encodeURIComponent(categoryName)}`}
+          className="text-primary flex items-center gap-2 underline"
+        >
+          View all affected items
+          <HiOutlineArrowUpRight />
+        </Link>
+        <p className="text-danger">If you are sure you may still proceed with deletion.</p>
+      </>
     );
   } else if (impactedItemsCount === 0) {
     dialogContent = <p>This category is not assigned to any item.</p>;

--- a/apps/web/src/features/category/components/CategoryDeleteModal.tsx
+++ b/apps/web/src/features/category/components/CategoryDeleteModal.tsx
@@ -48,7 +48,7 @@ export default function CategoryDeleteModal(props: CategoryDeleteModalProps) {
     );
   } else if (isError) {
     dialogContent = (
-      <>
+      <div className="bg-danger/10 border-danger flex flex-col gap-2 rounded-md border p-4">
         <p className="text-danger">
           Could not load impact data. Any item which has this category assigned will be
           uncategorized. You can check manually on the items page or try again later.
@@ -61,7 +61,7 @@ export default function CategoryDeleteModal(props: CategoryDeleteModalProps) {
           <HiOutlineArrowUpRight />
         </Link>
         <p className="text-danger">If you are sure you may still proceed with deletion.</p>
-      </>
+      </div>
     );
   } else if (impactedItemsCount === 0) {
     dialogContent = <p>This category is not assigned to any item.</p>;

--- a/apps/web/src/features/category/components/CategoryView.tsx
+++ b/apps/web/src/features/category/components/CategoryView.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 
+import { Alert } from '@repo/react-common/alert';
 import { Button } from '@repo/react-common/button';
 
 import { useAllCategories } from '../queries';
@@ -26,7 +27,7 @@ export function CategoryView({
   const [editCategoryId, setEditCategoryId] = useState<string | null>(null);
   const [deleteCategory, setDeleteCategory] = useState<Category | null>(null);
 
-  const { data = [], isLoading } = useAllCategories();
+  const { data = [], isLoading, isError } = useAllCategories();
   const editCategory = data.find((category) => category.id === editCategoryId);
 
   const closeForm = useCallback(() => {
@@ -61,6 +62,14 @@ export function CategoryView({
   const closeDeleteModal = useCallback(() => {
     setDeleteCategory(null);
   }, []);
+
+  if (isError && !data.length) {
+    return (
+      <div className="flex h-full w-full items-center justify-center p-8">
+        <Alert type="error" message="Failed to load categories. Please try again later." />
+      </div>
+    );
+  }
 
   let content: React.ReactNode = null;
   if (mode === 'table') {

--- a/apps/web/src/features/collection/components/CollectionsView.tsx
+++ b/apps/web/src/features/collection/components/CollectionsView.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo } from 'react';
 import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
+import { Alert } from '@repo/react-common/alert';
 import { useBreakpoint } from '@repo/react-common/hooks';
 import { Spinner } from '@repo/react-common/spinner';
 
@@ -31,7 +32,11 @@ export default function CollectionsView() {
     defaultSortField: 'name',
   });
 
-  const { data: collections = [], isLoading: isCollectionsLoading } = useAllCollections();
+  const {
+    data: collections = [],
+    isLoading: isCollectionsLoading,
+    isError: isCollectionsError,
+  } = useAllCollections();
   const { data: preferences, isLoading: isPreferencesLoading } = usePreferences();
   const isLoading = isCollectionsLoading || isPreferencesLoading;
 
@@ -138,6 +143,14 @@ export default function CollectionsView() {
     return (
       <div className="flex h-full w-full items-center justify-center">
         <Spinner size="large" />
+      </div>
+    );
+  }
+
+  if (isCollectionsError && !collections.length) {
+    return (
+      <div className="flex h-full w-full items-center justify-center p-8">
+        <Alert type="error" message="Failed to load collections. Please try again later." />
       </div>
     );
   }

--- a/apps/web/src/features/item/components/ItemDeleteModal.tsx
+++ b/apps/web/src/features/item/components/ItemDeleteModal.tsx
@@ -5,7 +5,6 @@ import toast from 'react-hot-toast';
 import { ConfirmationDialog } from '@repo/react-common/confirmation-dialog';
 
 import { Modal } from '@/components/Modal';
-import { extractErrorMessage } from '@/utils/extractApiErrorDetails';
 
 import { useDeleteItem } from '../queries';
 
@@ -23,9 +22,6 @@ export default function ItemDeleteModal(props: ItemDeleteModalProps) {
       onSuccess: () => {
         toast.success('Item deleted successfully');
         onClose();
-      },
-      onError: (error) => {
-        toast.error(`Error: ${extractErrorMessage(error)}`);
       },
     });
   };

--- a/apps/web/src/features/item/components/ItemsView.tsx
+++ b/apps/web/src/features/item/components/ItemsView.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
+import { Alert } from '@repo/react-common/alert';
 import { useBreakpoint } from '@repo/react-common/hooks';
 import { Spinner } from '@repo/react-common/spinner';
 
@@ -32,7 +33,7 @@ export default function ItemsView() {
   });
 
   const [deleteItemId, setDeleteItemId] = useState<string | null>(null);
-  const { data = [], isLoading: isItemsLoading } = useAllItems();
+  const { data = [], isLoading: isItemsLoading, isError: isItemsError } = useAllItems();
   const { data: preferences, isLoading: isPreferencesLoading } = usePreferences();
   const isLoading = isItemsLoading || isPreferencesLoading;
 
@@ -152,6 +153,14 @@ export default function ItemsView() {
     return (
       <div className="flex h-full w-full items-center justify-center">
         <Spinner size="large" />
+      </div>
+    );
+  }
+
+  if (isItemsError && !data.length) {
+    return (
+      <div className="flex h-full w-full items-center justify-center p-8">
+        <Alert type="error" message="Failed to load items. Please try again later." />
       </div>
     );
   }

--- a/apps/web/src/features/settings/components/PreferencesForm.tsx
+++ b/apps/web/src/features/settings/components/PreferencesForm.tsx
@@ -1,16 +1,14 @@
 'use client';
 
 import { ComponentType } from 'react';
-import toast from 'react-hot-toast';
 import { MdDarkMode, MdLightMode } from 'react-icons/md';
 
 import { DateFormat, Theme, TimeFormat, Units } from '@repo/constants';
+import { Alert } from '@repo/react-common/alert';
 import { IconToggleOption, InputIconToggle } from '@repo/react-common/input';
 import { Spinner } from '@repo/react-common/spinner';
 
 import classNames from 'classnames';
-
-import { extractErrorMessage } from '@/utils/extractApiErrorDetails';
 
 import { usePreferences, useUpdatePreferences } from '../queries';
 import { UpdatePreferencesBody } from '../types';
@@ -63,11 +61,7 @@ export function PreferencesForm() {
   const { mutate: updatePreferences, isPending } = useUpdatePreferences();
 
   const handleChange = (body: UpdatePreferencesBody) => {
-    updatePreferences(body, {
-      onError: (error) => {
-        toast.error(`Could not update preferences: ${extractErrorMessage(error)}`);
-      },
-    });
+    updatePreferences(body);
   };
 
   if (isLoading || !preferences) {
@@ -80,8 +74,8 @@ export function PreferencesForm() {
 
   if (isError) {
     return (
-      <div className="bg-danger text-danger-foreground border-danger-ring flex w-full flex-col rounded-md border p-4 shadow-sm">
-        Failed to load preferences. Please try again later.
+      <div className="flex h-full w-full items-center justify-center">
+        <Alert type="error" message="Failed to load preferences. Please try again later." />
       </div>
     );
   }

--- a/apps/web/src/hooks/useFormState.ts
+++ b/apps/web/src/hooks/useFormState.ts
@@ -1,9 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import toast from 'react-hot-toast';
 
-import { extractErrorMessage } from '@/utils/extractApiErrorDetails';
 import { getFieldErrorsFromHttpError } from '@/utils/getFieldErrors';
 
 export function useFormState<TValues extends Record<string, string>>(
@@ -33,7 +31,6 @@ export function useFormState<TValues extends Record<string, string>>(
       return;
     }
     setFieldErrors({});
-    toast.error(`Error: ${extractErrorMessage(error)}`);
   };
 
   return { formValues, fieldErrors, setFieldErrors, handleFieldChange, handleReset, handleError };


### PR DESCRIPTION
- all ReactQuery errors, app-wide, trigger toasts via `Providers.tsx` `onError`  config, if they are not field errors or session expired errors
- if prefetching fails, for any route, user gets a toast via Providers
    - Server-side prefetchQuery errors are silently swallowed by React Query (by design). The dehydrated state arrives at the client with no data. The client's useQuery then fetches on mount (cache is empty, so staleTime doesn't apply). If that fetch also fails, QueryCache.onError fires → toast. If it succeeds, data loads normally, no toast needed. So the toast fires iff there's an unrecoverable failure, which is correct.
- if clientside refresh fails, and data is cached, user gets a toast via Providers
- if clientside refresh fails, and no data is cached, instead of confusing 'there is no data' (shown if there is effectively no data in database) user gets Alert message and toast via Providers
- if mutation fails, and not because of field errors, user gets a toast via Providers