### PR TITLE
[Shared] API Dockerfile fix

### DIFF
--- a/apps/auth-service/Dockerfile
+++ b/apps/auth-service/Dockerfile
@@ -17,6 +17,7 @@ RUN yarn install --immutable
 # --- Build ---
 FROM installer AS builder
 COPY --from=pruner /app/out/full/ .
+ENV POSTGRES_ADMIN_URL=postgresql://build:build@localhost:5432/build
 RUN yarn turbo run build --filter=auth-service
 
 # --- Production runner ---

--- a/apps/product-service/Dockerfile
+++ b/apps/product-service/Dockerfile
@@ -17,6 +17,7 @@ RUN yarn install --immutable
 # --- Build ---
 FROM installer AS builder
 COPY --from=pruner /app/out/full/ .
+ENV POSTGRES_ADMIN_URL=postgresql://build:build@localhost:5432/build
 RUN yarn turbo run build --filter=product-service
 
 # --- Production runner ---

--- a/apps/user-data-service/Dockerfile
+++ b/apps/user-data-service/Dockerfile
@@ -17,6 +17,7 @@ RUN yarn install --immutable
 # --- Build ---
 FROM installer AS builder
 COPY --from=pruner /app/out/full/ .
+ENV POSTGRES_ADMIN_URL=postgresql://build:build@localhost:5432/build
 RUN yarn turbo run build --filter=user-data-service
 
 # --- Production runner ---


### PR DESCRIPTION
APIs depend on repo/db for generating the http clients so they need a dummy url in Dockerfile