### PR TITLE
[Web] script naming conflict fix

### DIFF
--- a/apps/auth-service/Dockerfile
+++ b/apps/auth-service/Dockerfile
@@ -17,6 +17,7 @@ RUN yarn install --immutable
 # --- Build ---
 FROM installer AS builder
 COPY --from=pruner /app/out/full/ .
+ENV POSTGRES_ADMIN_URL=postgresql://build:build@localhost:5432/build
 RUN yarn turbo run build --filter=auth-service
 
 # --- Production runner ---

--- a/apps/product-service/Dockerfile
+++ b/apps/product-service/Dockerfile
@@ -17,6 +17,7 @@ RUN yarn install --immutable
 # --- Build ---
 FROM installer AS builder
 COPY --from=pruner /app/out/full/ .
+ENV POSTGRES_ADMIN_URL=postgresql://build:build@localhost:5432/build
 RUN yarn turbo run build --filter=product-service
 
 # --- Production runner ---

--- a/apps/user-data-service/Dockerfile
+++ b/apps/user-data-service/Dockerfile
@@ -17,6 +17,7 @@ RUN yarn install --immutable
 # --- Build ---
 FROM installer AS builder
 COPY --from=pruner /app/out/full/ .
+ENV POSTGRES_ADMIN_URL=postgresql://build:build@localhost:5432/build
 RUN yarn turbo run build --filter=user-data-service
 
 # --- Production runner ---

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "openapi:auth": "turbo run openapi --filter=auth-service",
     "openapi:product": "turbo run openapi --filter=product-service",
     "openapi:user-data": "turbo run openapi --filter=user-data-service",
-    "generate:auth-client": "yarn workspace @repo/auth-client generate",
-    "generate:product-client": "yarn workspace @repo/product-client generate",
-    "generate:user-data-client": "yarn workspace @repo/user-data-client generate",
+    "generate:auth-client": "yarn workspace @repo/auth-client generate:client",
+    "generate:product-client": "yarn workspace @repo/product-client generate:client",
+    "generate:user-data-client": "yarn workspace @repo/user-data-client generate:client",
     "storybook": "turbo run storybook"
   },
   "devDependencies": {

--- a/packages/auth-client/package.json
+++ b/packages/auth-client/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "generate": "openapi-typescript ../../apps/auth-service/openapi.json -o src/schema.d.ts && openapi-zod-client ../../apps/auth-service/openapi.json -o src/schema.zod.ts --template ./scripts/schemas-only.hbs && prettier --write src/schema.d.ts src/schema.zod.ts",
+    "generate:client": "openapi-typescript ../../apps/auth-service/openapi.json -o src/schema.d.ts && openapi-zod-client ../../apps/auth-service/openapi.json -o src/schema.zod.ts --template ./scripts/schemas-only.hbs && prettier --write src/schema.d.ts src/schema.zod.ts",
     "build": "tsc"
   },
   "exports": {

--- a/packages/product-client/package.json
+++ b/packages/product-client/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "generate": "openapi-typescript ../../apps/product-service/openapi.json -o src/schema.d.ts && openapi-zod-client ../../apps/product-service/openapi.json -o src/schema.zod.ts --template ./scripts/schemas-only.hbs && prettier --write src/schema.d.ts src/schema.zod.ts",
+    "generate:client": "openapi-typescript ../../apps/product-service/openapi.json -o src/schema.d.ts && openapi-zod-client ../../apps/product-service/openapi.json -o src/schema.zod.ts --template ./scripts/schemas-only.hbs && prettier --write src/schema.d.ts src/schema.zod.ts",
     "build": "tsc"
   },
   "exports": {

--- a/packages/user-data-client/package.json
+++ b/packages/user-data-client/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "generate": "openapi-typescript ../../apps/user-data-service/openapi.json -o src/schema.d.ts && openapi-zod-client ../../apps/user-data-service/openapi.json -o src/schema.zod.ts --template ./scripts/schemas-only.hbs && prettier --write src/schema.d.ts src/schema.zod.ts",
+    "generate:client": "openapi-typescript ../../apps/user-data-service/openapi.json -o src/schema.d.ts && openapi-zod-client ../../apps/user-data-service/openapi.json -o src/schema.zod.ts --template ./scripts/schemas-only.hbs && prettier --write src/schema.d.ts src/schema.zod.ts",
     "build": "tsc"
   },
   "exports": {

--- a/turbo.json
+++ b/turbo.json
@@ -10,7 +10,7 @@
   ],
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "^generate"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": ["dist/**", ".next/**", "!.next/cache/**", "storybook-static/**"],
       "env": [
@@ -107,6 +107,11 @@
       "dependsOn": ["generate"],
       "inputs": ["prisma/schema.prisma", "prisma/seed.mts"],
       "env": ["POSTGRES_*"]
+    },
+    "generate:client": {
+      "cache": false,
+      "inputs": ["../../apps/*/openapi.json", "scripts/**"],
+      "outputs": ["src/schema.d.ts", "src/schema.zod.ts"]
     },
     "openapi": {
       "dependsOn": ["build"],


### PR DESCRIPTION
build script DOES need generate
repo/db needs to run prisma generate for producing Typescript Types
then repo/dv DOES need the dummy POSTGRES_ADMIN_URL vars as otherwise prisma.config.mts throws

httpclients use 'generate' but do something different. better solution = renaming these scripts