### PR TITLE
[Web] getter for authSecret to avoid validation at buildtime

### DIFF
--- a/apps/web/src/lib/session.ts
+++ b/apps/web/src/lib/session.ts
@@ -16,29 +16,30 @@ export interface SessionData {
 
 export const SESSION_COOKIE_NAME = 'pyb-session';
 
-/**
- * AUTH_SECRET doubles as the iron-session encryption password.
- * Must be at least 32 characters.
- */
-const authSecret = process.env.AUTH_SECRET;
-if (!authSecret || authSecret.length < 32) {
-  throw new Error('AUTH_SECRET must be set and at least 32 characters');
+function getAuthSecret(): string {
+  const secret = process.env.AUTH_SECRET;
+  if (!secret || secret.length < 32) {
+    throw new Error('AUTH_SECRET must be set and at least 32 characters');
+  }
+  return secret;
 }
 
-export const sessionOptions: SessionOptions = {
-  password: authSecret,
-  cookieName: SESSION_COOKIE_NAME,
-  cookieOptions: {
-    httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
-    sameSite: 'lax',
-  },
-};
+export function getSessionOptions(): SessionOptions {
+  return {
+    password: getAuthSecret(),
+    cookieName: SESSION_COOKIE_NAME,
+    cookieOptions: {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+    },
+  };
+}
 
 /**
  * For use in Route Handlers and Server Actions only.
  * Middleware must use getIronSession(req, res, sessionOptions) directly.
  */
 export async function getSession() {
-  return getIronSession<SessionData>(await cookies(), sessionOptions);
+  return getIronSession<SessionData>(await cookies(), getSessionOptions());
 }

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -4,7 +4,7 @@ import * as Sentry from '@sentry/nextjs';
 import { getIronSession } from 'iron-session';
 
 import { getAuthConfig } from '@/lib/clients/auth-config';
-import { SESSION_COOKIE_NAME, type SessionData, sessionOptions } from '@/lib/session';
+import { getSessionOptions, SESSION_COOKIE_NAME, type SessionData } from '@/lib/session';
 
 import { AUTH_REDIRECT_PATHS, PUBLIC_PATHS } from './lib/constants';
 
@@ -116,7 +116,7 @@ async function handleRequest(req: NextRequest, nonce: string): Promise<NextRespo
   const shouldRedirectIfAuthed = AUTH_REDIRECT_PATHS.some((p) => pathname.startsWith(p));
 
   // Read the session from the request cookie (temp response — we won't save to it).
-  const session = await getIronSession<SessionData>(req, new NextResponse(), sessionOptions);
+  const session = await getIronSession<SessionData>(req, new NextResponse(), getSessionOptions());
 
   if (isPublic) {
     // Redirect already-authenticated users away from auth-related pages.
@@ -158,7 +158,7 @@ async function handleRequest(req: NextRequest, nonce: string): Promise<NextRespo
     const response = NextResponse.next({ request: { headers: requestHeaders } });
 
     // Write refreshed tokens to the session cookie on the response.
-    const sessionToSave = await getIronSession<SessionData>(req, response, sessionOptions);
+    const sessionToSave = await getIronSession<SessionData>(req, response, getSessionOptions());
     sessionToSave.isLoggedIn = true;
     sessionToSave.userId = session.userId;
     sessionToSave.role = session.role;


### PR DESCRIPTION
top level code runs when module is imported
AUTH_SECRET is not present yet at buildtime though
making a getter defers execution to runtime