### PR TITLE
[Web] Healthcheck fix

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -104,7 +104,7 @@ services:
       user-data-service:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/ || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/login || exit 1"]
       interval: 15s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
health check uses wget -qO- http://localhost:3000/, but / goes through the middleware which redirects unauthenticated requests to /login (302). wget without -S treats redirects as failures.