### PR TITLE
[Web] preferences throttler issue

### DIFF
--- a/apps/web/src/features/settings/queries.ts
+++ b/apps/web/src/features/settings/queries.ts
@@ -55,8 +55,8 @@ const useCreatePreferences = () => {
 
   return useMutation({
     mutationFn: createPreferences,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['preferences'] });
+    onSuccess: (data) => {
+      queryClient.setQueryData(['preferences'], data);
     },
   });
 };


### PR DESCRIPTION
The fix replaces invalidateQueries with setQueryData(data). Since createPreferences already returns the full preferences object from the server, we write it directly into the cache. This synchronously updates data from null to the real preferences, so by the time the effect re-runs, data !== null and it bails out. No need for an async refetch of something we already have.